### PR TITLE
Add dataset upload and preview

### DIFF
--- a/config.json
+++ b/config.json
@@ -4,61 +4,71 @@
       "title": "EHR Data",
       "href": "https://raw.githubusercontent.com/gramener/datasets/refs/heads/main/ehr.csv",
       "audience": "Given a Pandas DataFrame df, generate 8 use cases useful for a launch effectiveness team in a pharmaceutical company as JSON. The pharmaceutical company has invented a pill which is as effective and safe as an injectable. They want to maximize the possible target market and patients to reach out to. Target patients could be those who are already on injectables, those who are on pills but are ready to switch to injectables, and those who face barriers or challenges with current injectable therapies. Think holistically, incorporating clinical, geographical, behavioral, and socio-economic factors to maximize the target market for an impactful drug launch. Ensure that all generated hypotheses are solely based on the data available in the given dataset.",
-      "body": "Electronic Health Records covering patient demographics, clinical metrics, comorbidities, medications, etc. over time"
+      "body": "Electronic Health Records covering patient demographics, clinical metrics, comorbidities, medications, etc. over time",
+      "context": "Identify patient groups to maximize reach of the new pill"
     },
     {
       "title": "Supply Chain",
       "href": "https://raw.githubusercontent.com/gramener/datasets/refs/heads/main/supply_chain.csv",
       "audience": "Senior management of a fashion & beauty supply chain organization",
-      "body": "Explore insights from supply chain data from a fashion & beauty store's makeup products."
+      "body": "Explore insights from supply chain data from a fashion & beauty store's makeup products.",
+      "context": "Optimize inventory and reduce logistics delays"
     },
     {
       "title": "Tourist Spend",
       "href": "https://raw.githubusercontent.com/gramener/datasets/refs/heads/main/tourists.csv",
       "audience": "Given tourist spend data, generate insights on how a government tourism department can increase tourist spend in the country.",
-      "body": "Tourist spend data with details on issuer country, transaction amount, and other details."
+      "body": "Tourist spend data with details on issuer country, transaction amount, and other details.",
+      "context": "Increase tourist spending by targeting key demographics"
     },
     {
       "title": "Card Transactions",
       "href": "https://raw.githubusercontent.com/gramener/datasets/main/card_transactions.csv",
       "audience": "Given card transaction data, generate insights on consumer spending behavior, fraud detection, and financial trends. This information can be valuable for financial analysts, marketers, and risk management professionals.",
-      "body": "Card transactions data with details on issuer country, transaction amount, and other details."
+      "body": "Card transactions data with details on issuer country, transaction amount, and other details.",
+      "context": "Spot fraudulent behavior and understand spending patterns"
     },
     {
       "title": "HR: Employee Data",
       "href": "https://raw.githubusercontent.com/gramener/datasets/main/employee_data.csv",
       "audience": "Given employee data, generate insights on workforce demographics, performance analysis, and salary trends. This information can be valuable for HR professionals, organizational leaders, and data analysts.",
-      "body": "Employee master data with demographics, job details, hierarchy, salary, performance, and other details."
+      "body": "Employee master data with demographics, job details, hierarchy, salary, performance, and other details.",
+      "context": "Improve retention and manage workforce costs"
     },
     {
       "title": "Marvel Powers",
       "href": "https://raw.githubusercontent.com/sanand0/marvel-powers/master/marvel-powers-summary.csv",
       "audience": "Given data on Marvel characters and their powers, generate insights for fans, game developers, and researchers interested in character abilities and dynamics within the Marvel universe.",
-      "body": "Every Marvel character and variant along with their powers (at their weakest and strongest) from Marvel Fandom."
+      "body": "Every Marvel character and variant along with their powers (at their weakest and strongest) from Marvel Fandom.",
+      "context": "Explore character strengths for better game design"
     },
     {
       "title": "World",
       "href": "https://raw.githubusercontent.com/gramener/datasets/main/world.db",
       "audience": "Given a database of states and cities, generate insights on urbanization trends, migration patterns, and regional economic development. This data can be useful for urban planners, policymakers, and researchers interested in geographical and demographic studies.",
-      "body": "A database of 239 states and their cities."
+      "body": "A database of 239 states and their cities.",
+      "context": "Study urbanization and migration across regions"
     },
     {
       "title": "NBA",
       "href": "https://raw.githubusercontent.com/gramener/datasets/main/nba.db",
       "audience": "Given NBA match data, generate insights on player performance, team dynamics, and game strategies. This information can be valuable for sports analysts, coaches, and fans.",
-      "body": "A database with information about basketball matches from the National Basketball Association. Lists Players, Teams, and matches with action counts for each player."
+      "body": "A database with information about basketball matches from the National Basketball Association. Lists Players, Teams, and matches with action counts for each player.",
+      "context": "Improve team strategy using player performance"
     },
     {
       "title": "CraftBeer",
       "href": "https://raw.githubusercontent.com/gramener/datasets/main/craftbeer.db",
       "audience" : "Given craft beer data, generate insights on consumer preferences, market trends, and brewing techniques. This information can be valuable for brewers, marketers, and enthusiasts.",
-      "body": "Craft beers labeled by styles and composition. A separate dataset lists breweries by state."
+      "body": "Craft beers labeled by styles and composition. A separate dataset lists breweries by state.",
+      "context": "Identify popular styles to grow craft beer sales"
     },
     {
       "title": "Atherosclerosis",
       "href": "https://raw.githubusercontent.com/gramener/datasets/main/atherosclerosis.db",
       "audience" : "Given data on atherosclerosis, generate insights on cardiovascular health trends, risk factors, and preventive measures. This information can be valuable for healthcare professionals, researchers, and public health officials.",
-      "body": "Atherosclerosis is a longitudinal 20 years lasting primary preventive study of middle-aged men."
+      "body": "Atherosclerosis is a longitudinal 20 years lasting primary preventive study of middle-aged men.",
+      "context": "Understand risk factors in cardiovascular health"
     }
   ]
 }

--- a/index.html
+++ b/index.html
@@ -5,10 +5,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Hypothesis Forge</title>
-  <link
-    rel="icon"
-    type="image/svg+xml"
-    href="data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAzMiAzMiI+PGNpcmNsZSBjeD0iMTYiIGN5PSIxNiIgcj0iMTUiIGZpbGw9IiMyNTYzZWIiLz48cGF0aCBmaWxsPSIjZmZmIiBkPSJtMTYgNyAyIDcgNyAyLTcgMi0yIDctMi03LTctMiA3LTJaIi8+PC9zdmc+" />
+  <link rel="icon" type="image/svg+xml" href="data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAzMiAzMiI+PGNpcmNsZSBjeD0iMTYiIGN5PSIxNiIgcj0iMTUiIGZpbGw9IiMyNTYzZWIiLz48cGF0aCBmaWxsPSIjZmZmIiBkPSJtMTYgNyAyIDcgNyAyLTcgMi0yIDctMi03LTctMiA3LTJaIi8+PC9zdmc+" />
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.6/dist/css/bootstrap.min.css" crossorigin="anonymous" />
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/highlight.js@11.9.0/styles/github-dark.min.css" crossorigin="anonymous">
   <style>
@@ -31,6 +28,7 @@
     .outcome.failure h5 {
       color: var(--bs-danger);
     }
+
   </style>
 </head>
 
@@ -142,19 +140,11 @@
               <div class="accordion-body">
                 <div class="mb-3">
                   <label for="hypothesis-prompt" class="form-label fw-bold">Hypothesis Generation Prompt</label>
-                  <textarea
-                    id="hypothesis-prompt"
-                    class="form-control font-monospace"
-                    rows="5"
-                    placeholder="Enter custom prompt for hypothesis generation (optional)"></textarea>
+                  <textarea id="hypothesis-prompt" class="form-control font-monospace" rows="5" placeholder="Enter custom prompt for hypothesis generation (optional)"></textarea>
                 </div>
                 <div class="mb-3">
                   <label for="analysis-prompt" class="form-label fw-bold">Analysis Prompt</label>
-                  <textarea
-                    id="analysis-prompt"
-                    class="form-control font-monospace"
-                    rows="5"
-                    placeholder="Enter custom prompt for analysis (optional)">You are an expert data analyst. Test the given hypothesis on the provided Pandas DataFrame (df) as follows:
+                  <textarea id="analysis-prompt" class="form-control font-monospace" rows="5" placeholder="Enter custom prompt for analysis (optional)">You are an expert data analyst. Test the given hypothesis on the provided Pandas DataFrame (df) as follows:
 
 1. Create derived columns ONLY IF REQUIRED. E.g. If "CurrentMedication" contains "insulin", classify it as "Injectable", otherwise as "Pill".
 2. If that's not possible, provide the best possible answer based on available data to the hypothesis, making assumptions.
@@ -191,7 +181,18 @@ def test_hypothesis(df) -> (bool, float):
       </div>
     </form>
 
-    <div id="demos" class="row row-cols-1 row-cols-sm-2 row-cols-lg-3 row-cols-xl-4 my-5 justify-content-center"></div>
+    <div class="my-4" id="dataset-select">
+      <div class="dropdown d-inline-block me-2">
+        <button class="btn btn-secondary dropdown-toggle" type="button" data-bs-toggle="dropdown" id="demo-dropdown">Sample datasets</button>
+        <ul class="dropdown-menu list-group" id="demo-list"></ul>
+      </div>
+      <input type="file" class="form-control d-inline-block w-auto" id="file-input" accept=".csv,.sqlite,.db" />
+    </div>
+    <div id="preview" class="container-fluid"></div>
+    <div id="context-section" class="container-fluid d-none">
+      <textarea id="context" class="form-control my-2" rows="4"></textarea>
+      <button type="button" class="btn btn-primary" id="generate-hypotheses">Generate hypotheses</button>
+    </div>
     <div id="hypotheses" class="row row-cols-1 row-cols-sm-2 row-cols-lg-3 my-5 justify-content-center"></div>
     <div id="synthesis" class="d-none">
       <div class="text-center">


### PR DESCRIPTION
## Problem
Users couldn't upload their own datasets or preview data before generating hypotheses.

## Changes Made
- Added `context` field to each sample dataset in `config.json`
- Replaced dataset cards with a dropdown and file upload in `index.html`
- Implemented dataset preview, context textarea and generation workflow in `script.js`

## Review Notes
- UI changes in `index.html` are minimal and use Bootstrap components
- `script.js` now handles preview rendering, file uploads and manual hypothesis generation
- Config additions don't alter existing dataset links

## Verification Steps
1. Serve the repo via `python -m http.server`
2. Open the site and choose a sample dataset from the dropdown or upload a CSV
3. Verify that a table preview appears with a context box and "Generate hypotheses" button
4. Click the button to generate hypotheses and test them as before

## Deployment Risks
- Requires modern browser due to ES modules
- No server-side changes; static hosting remains safe

## Learning
This PR shows how to enrich a simple static app with user uploads and dynamic previews using minimal JavaScript and Bootstrap.

------
https://chatgpt.com/codex/tasks/task_e_685358ced664832c91b89b64c9a1e98a